### PR TITLE
Fix ordering with joined tables

### DIFF
--- a/lib/acts_as_orderable.rb
+++ b/lib/acts_as_orderable.rb
@@ -10,7 +10,7 @@ module Acts
       # Should new element be first || last
       def acts_as_orderable(*sources)
         class_eval <<-END
-          scope :ordered, ->{ order('element_order ASC') }
+          scope :ordered, ->{ order(:element_order) }
           after_create :init_me!
           include Acts::AsOrderable::InstanceMethods
         END


### PR DESCRIPTION
This commit should fix the following issue:
When you have two orderable models that have many_to_many relation, then attempt to query them ordered will fail with complain about 'element_order' ambiguity. So we need to add table name before the field value.
Since rails 4 (or maybe 3?) it is done automatically in the way specified in the commit. 
